### PR TITLE
docs: add SSL options documentation to env template

### DIFF
--- a/client/nuxt.config.ts
+++ b/client/nuxt.config.ts
@@ -1,7 +1,7 @@
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default {
 	buildModules: ["@nuxtjs/google-fonts"],
-	modules: ["@nuxtjs/tailwindcss", "@nuxtus/nuxt-module"],
+	modules: ["@nuxtjs/tailwindcss", "@resultcrafter/nuxtus-nuxt-module"],
 	googleFonts: {
 		families: {
 			Inter: true,

--- a/client/package.json
+++ b/client/package.json
@@ -9,8 +9,8 @@
   "devDependencies": {
     "@nuxtjs/google-fonts": "3.2.0",
     "@nuxtjs/tailwindcss": "6.14.0",
-    "@nuxtus/cli": "2.1.4",
-    "@nuxtus/nuxt-module": "2.4.3",
+    "@resultcrafter/nuxtus-cli": "2.1.5",
+    "@resultcrafter/nuxtus-nuxt-module": "2.4.4",
     "nuxt": "^3.10.2"
   },
   "dependencies": {

--- a/templates/env-directus.liquid
+++ b/templates/env-directus.liquid
@@ -52,6 +52,12 @@ PUBLIC_URL="/"
 
 {{ database }}
 
+# SSL options for remote databases (PostgreSQL, CockroachDB)
+# Uncomment and adjust if you experience SSL connection issues:
+# DB_SSL__REJECT_UNAUTHORIZED="false"
+# DB_SSL__CA="/path/to/ca-cert.pem"
+# DB_SSL__CERT="/path/to/client-cert.pem"
+# DB_SSL__KEY="/path/to/client-key.pem"
 
 # These match the databases defined in the docker-compose file in the root of this repo
 


### PR DESCRIPTION
Add commented SSL configuration options (DB_SSL__REJECT_UNAUTHORIZED, DB_SSL__CA, DB_SSL__CERT, DB_SSL__KEY) after database block